### PR TITLE
feat(ZRZ-613): Add support for contents array

### DIFF
--- a/src/ecommerce.ts
+++ b/src/ecommerce.ts
@@ -33,6 +33,36 @@ const getContentIds = (payload: any) => {
   ]
 }
 
+const getContents = (payload: any) => {
+  return [
+    ...(((payload.sku || payload.product_id) && [
+      {
+        id: payload.sku || payload.product_id,
+        quantity: payload.quantity,
+        item_price: payload.price,
+        delivery_category:
+          payload.delivery_category ||
+          payload.shipping_tier ||
+          payload.shipping,
+      },
+    ]) ||
+      []),
+    ...(payload.products?.map(
+      (p: any) =>
+        ((p.sku || p.product_id) && [
+          {
+            id: p.sku || p.product_id,
+            quantity: p.quantity,
+            item_price: p.price,
+            delivery_category:
+              p.delivery_category || p.shipping_tier || p.shipping,
+          },
+        ]) ||
+        []
+    ) || []),
+  ]
+}
+
 const getValue = (payload: any) =>
   payload.value || payload.price || payload.total || payload.revenue
 
@@ -46,6 +76,7 @@ const mapEcommerceData = (event: MCEvent) => {
   custom_data.content_type = 'product'
   custom_data.content_ids = getContentIds(data)
   custom_data.content_name = getContentName(data)
+  custom_data.contents = getContents(data)
   custom_data.content_category = data.category
   custom_data.value = getValue(data)
   data.order_id && (custom_data.order_id = data.order_id)

--- a/src/ecommerce.ts
+++ b/src/ecommerce.ts
@@ -40,10 +40,6 @@ const getContents = (payload: any) => {
         id: payload.sku || payload.product_id,
         quantity: payload.quantity,
         item_price: payload.price,
-        delivery_category:
-          payload.delivery_category ||
-          payload.shipping_tier ||
-          payload.shipping,
       },
     ]) ||
       []),
@@ -54,8 +50,6 @@ const getContents = (payload: any) => {
             id: p.sku || p.product_id,
             quantity: p.quantity,
             item_price: p.price,
-            delivery_category:
-              p.delivery_category || p.shipping_tier || p.shipping,
           },
         ]) ||
         []


### PR DESCRIPTION
Hi all, this adds support for the contents array as found in https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/custom-data/#contents

- [ ] I wasn't sure about the `delivery_category`, which may be called `shipping_tier` in other MCs. Please review that so we can change it accordingly. Otherwise, this should be good to go.